### PR TITLE
successfully used context in order to pass props as opposed to prop t…

### DIFF
--- a/src/components/Cockpit/Cockpit.js
+++ b/src/components/Cockpit/Cockpit.js
@@ -1,13 +1,17 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import styles from "./Cockpit.module.css";
+import AuthContext from "../../context/auth-context";
 import classes from "./Cockpit.module.css";
 
 const Cockpit = props => {
+  const toggleBtnRef = useRef(null);
+
   useEffect(() => {
-    console.log("[cockpit.js] useEffect");
-    setTimeout(() => {
-      alert("save data to cloud");
-    }, 1000);
+    // console.log("[cockpit.js] useEffect");
+    // setTimeout(() => {
+    //   alert("save data to cloud");
+    // }, 1000);
+    toggleBtnRef.current.click();
     return () => {
       console.log("[Cockpit.js] cleanup work");
     };
@@ -34,9 +38,12 @@ const Cockpit = props => {
     <div className={styles.Cockpit}>
       <h1>{props.title}</h1>
       <p className={assignedClasses.join(" ")}>This is really working!</p>
-      <button className={btnClass} onClick={props.clicked}>
+      <button ref={toggleBtnRef} className={btnClass} onClick={props.clicked}>
         Toggle Persons
       </button>
+      <AuthContext.Consumer>
+        {context => <button onClick={context.login}>Log In</button>}
+      </AuthContext.Consumer>
     </div>
   );
 };

--- a/src/components/Persons/Person/Person.js
+++ b/src/components/Persons/Person/Person.js
@@ -3,18 +3,33 @@ import PropTypes from "prop-types";
 import Aux from "../../../hoc/Aux";
 import withClass from "../../../hoc/withClass";
 import classes from "./Person.module.css";
+import AuthContext from "../../../context/auth-context";
 class Person extends Component {
+  constructor(props) {
+    super(props);
+    this.inputRef = React.createRef();
+  }
+  componentDidMount() {
+    this.inputRef.current.focus();
+  }
   render() {
     console.log("[Person.js] rendering...");
 
     return (
       <Aux>
+        <AuthContext.Consumer>
+          {context =>
+            context.authenticated ? <p>Authenticated!</p> : <p>Please Log In</p>
+          }
+        </AuthContext.Consumer>
+
         <p onClick={this.props.click}>
           I'm {this.props.name} and I am {this.props.age} years old!
         </p>
         <p key="i2">{this.props.children}</p>
         <input
           key="i3"
+          ref={this.inputRef}
           type="text"
           onChange={this.props.changed}
           value={this.props.name}

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,6 +4,7 @@ import Persons from "../components/Persons/Persons";
 import Aux from "../hoc/Aux";
 import classes from "./App.module.css";
 import withClass from "../hoc/withClass";
+import AuthContext from "../context/auth-context";
 
 class App extends Component {
   constructor(props) {
@@ -30,7 +31,8 @@ class App extends Component {
     ],
     showPersons: false,
     showCockpit: true,
-    changeCounter: 0
+    changeCounter: 0,
+    authenticated: false
   };
   static getDerivedStateFromProps(props, state) {
     console.log("[App.js] getDerivedStateFromProps", props);
@@ -79,6 +81,9 @@ class App extends Component {
     const doesShow = this.state.showPersons;
     this.setState({ showPersons: !doesShow });
   };
+  loginHandler = () => {
+    this.setState({ authenticated: true });
+  };
   render() {
     console.log("[App.js] render");
 
@@ -90,6 +95,7 @@ class App extends Component {
           persons={this.state.persons}
           clicked={this.deletePersonHandler}
           changed={this.nameChangeHandler}
+          isAuthenticated={this.state.authenticated}
         />
       );
     }
@@ -103,15 +109,23 @@ class App extends Component {
         >
           Remove Cockpit
         </button>
-        {this.state.showCockpit ? (
-          <Cockpit
-            title={this.props.appTitle}
-            showPersons={this.state.showPersons}
-            personsLength={this.state.persons.length}
-            clicked={this.togglePersonsHandler}
-          />
-        ) : null}
-        {persons}
+        <AuthContext.Provider
+          value={{
+            authenticated: this.state.authenticated,
+            login: this.loginHandler
+          }}
+        >
+          {this.state.showCockpit ? (
+            <Cockpit
+              title={this.props.appTitle}
+              showPersons={this.state.showPersons}
+              personsLength={this.state.persons.length}
+              clicked={this.togglePersonsHandler}
+              login={this.loginHandler}
+            />
+          ) : null}
+          {persons}
+        </AuthContext.Provider>
       </Aux>
     );
   }

--- a/src/context/auth-context.js
+++ b/src/context/auth-context.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const authContext = React.createContext({});
+
+export default authContext;


### PR DESCRIPTION
…unneling.  In this issue I used the context api in order to pass props regarding authentication to my person component as well as the cockpit component.  This prevents unnecessary prop tunneling. 